### PR TITLE
Add restart button and inline win messages

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -4,12 +4,39 @@
     <meta charset="UTF-8">
     <title>Gomoku WebGL</title>
     <style>
-        body { margin: 0; display: flex; justify-content: center; align-items: center; height: 100vh; background: #fafafa; }
-        canvas { border: 1px solid #333; }
+        body {
+            margin: 0;
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            height: 100vh;
+            background: #fafafa;
+        }
+        #container {
+            display: flex;
+            align-items: center;
+        }
+        #board-area {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+        }
+        canvas { border: 1px solid #333; margin-bottom: 10px; }
+        #message {
+            margin-left: 20px;
+            font-size: 1.2em;
+            min-width: 120px;
+        }
     </style>
 </head>
 <body>
-<canvas id="board" width="600" height="600"></canvas>
+<div id="container">
+    <div id="board-area">
+        <canvas id="board" width="600" height="600"></canvas>
+        <button id="startButton">Start</button>
+    </div>
+    <div id="message"></div>
+</div>
 <script type="module" src="script.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- update board layout and move Start button below the canvas
- disable Start button during play and change text to Restart after game ends
- display game messages beside the board and combine win/draw checks

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68650d50ad40832ab21b8830a8bd8150