### PR TITLE
Add option to choose first player

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -21,6 +21,14 @@
             flex-direction: column;
             align-items: center;
         }
+        #controls {
+            display: flex;
+            align-items: center;
+            margin-bottom: 10px;
+        }
+        #controls label {
+            margin-right: 10px;
+        }
         canvas { border: 1px solid #333; margin-bottom: 10px; }
         #message {
             margin-left: 20px;
@@ -33,7 +41,11 @@
 <div id="container">
     <div id="board-area">
         <canvas id="board" width="600" height="600"></canvas>
-        <button id="startButton">Start</button>
+        <div id="controls">
+            <label><input type="radio" id="playerFirst" name="starter" value="player" checked> You First</label>
+            <label><input type="radio" id="aiFirst" name="starter" value="ai"> AI First</label>
+            <button id="startButton">Start</button>
+        </div>
     </div>
     <div id="message"></div>
 </div>

--- a/web/script.js
+++ b/web/script.js
@@ -5,6 +5,8 @@ let BOARD_SIZE;
 const canvas = document.getElementById('board');
 const startButton = document.getElementById('startButton');
 const messageDiv = document.getElementById('message');
+const playerFirstRadio = document.getElementById('playerFirst');
+const aiFirstRadio = document.getElementById('aiFirst');
 
 const gl = canvas.getContext('webgl');
 if (!gl) {
@@ -208,6 +210,21 @@ function startGame() {
         animRequestId = null;
     }
     render();
+    if (aiFirstRadio.checked) {
+        game.switch_player();
+        const aiMove = game.ai_move();
+        game.make_move(aiMove[0], aiMove[1]);
+        const aiNow = performance.now();
+        recentMoves.push({ row: aiMove[0], col: aiMove[1], player: 2, time: aiNow });
+        lastMove = { row: aiMove[0], col: aiMove[1], player: 2, time: aiNow };
+        render();
+        const winner = game.check_winner();
+        if (winner === 2 || game.is_board_full()) {
+            endGame(winner === 2 ? 'AI wins' : 'Draw!');
+            return;
+        }
+        game.switch_player();
+    }
 }
 
 canvas.addEventListener('click', (e) => {


### PR DESCRIPTION
## Summary
- add radio buttons to choose who goes first
- draw radio controls left of the start button
- enable AI opening move when AI is selected to start

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68666bf69224832a9945d99e058c17b8