### PR TITLE
Allow AI to control either color

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains a simple console implementation of the Gomoku board gam
 ## Features
 
 - **Console Interface**: Text-based gameplay with a clear board display.
-- **Human vs. AI**: Play as Black (X) against an AI as White (O).
+- **Human vs. AI**: Choose whether the AI plays Black or White.
 - **Minimax AI**: AI uses Minimax with alpha-beta pruning (depth 3) for strategic moves.
 - **Win/Draw Detection**: Detects wins (five in a row) or draws (full board).
 - **Input Validation**: Ensures valid moves with error messages for invalid inputs.
@@ -29,6 +29,9 @@ This repository contains a simple console implementation of the Gomoku board gam
    ```bash
    cargo run
    ```
+   The program will ask if you want to move first. Moving first means you
+   play Black (X); otherwise the AI takes the Black stones and you play
+   White (O).
 3. Build the WebGL interface using [wasm-pack](https://rustwasm.github.io/wasm-pack/):
    ```bash
    wasm-pack build --target web

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,13 +7,49 @@ use std::io;
 /// board after each turn.
 fn main() {
     let mut game = Gomoku::new();
-    println!("Welcome to Gomoku! You are Black (X), AI is White (O).");
+    println!("Welcome to Gomoku!");
+    println!("Do you want to move first? (y/n)");
+    let mut input = String::new();
+    io::stdin().read_line(&mut input).expect("Failed to read input");
+    let human_first = input.trim().eq_ignore_ascii_case("y");
+
+    let (human_color, ai_color) = if human_first {
+        (Cell::Black, Cell::White)
+    } else {
+        (Cell::White, Cell::Black)
+    };
+
+    println!(
+        "You are {:?} ({}), AI is {:?} ({})",
+        human_color,
+        if human_color == Cell::Black { 'X' } else { 'O' },
+        ai_color,
+        if ai_color == Cell::Black { 'X' } else { 'O' }
+    );
     println!("Enter moves as 'row col' (e.g., '7 7').");
+
+    if !human_first {
+        println!("AI ({:?}) is thinking...", ai_color);
+        let (row, col) = game.ai_move();
+        println!("AI moves to ({}, {})", row, col);
+        game.make_move(row, col).expect("AI made an invalid move");
+        if let Some(winner) = game.check_winner() {
+            game.print_board();
+            println!("AI wins ({:?})!", winner);
+            return;
+        }
+        if game.is_board_full() {
+            game.print_board();
+            println!("Game is a draw!");
+            return;
+        }
+        game.switch_player();
+    }
 
     loop {
         game.print_board();
-        if game.current_player() == Cell::Black {
-            println!("Your turn (Black, X). Enter row and column (0-{}):", BOARD_SIZE - 1);
+        if game.current_player() == human_color {
+            println!("Your turn ({:?}). Enter row and column (0-{}):", human_color, BOARD_SIZE - 1);
             let mut input = String::new();
             io::stdin().read_line(&mut input).expect("Failed to read input");
             let coords: Vec<usize> = input
@@ -30,7 +66,7 @@ fn main() {
                 continue;
             }
         } else {
-            println!("AI (White, O) is thinking...");
+            println!("AI ({:?}) is thinking...", ai_color);
             let (row, col) = game.ai_move();
             println!("AI moves to ({}, {})", row, col);
             game.make_move(row, col).expect("AI made an invalid move");
@@ -39,8 +75,8 @@ fn main() {
         if let Some(winner) = game.check_winner() {
             game.print_board();
             match winner {
-                Cell::Black => println!("You win (Black, X)!"),
-                Cell::White => println!("AI wins (White, O)!"),
+                w if w == human_color => println!("You win ({:?})!", human_color),
+                w if w == ai_color => println!("AI wins ({:?})!", ai_color),
                 _ => unreachable!(),
             }
             break;

--- a/web/script.js
+++ b/web/script.js
@@ -221,7 +221,6 @@ function startGame() {
     }
     render();
     if (aiFirstRadio.checked) {
-        game.switch_player();
         const aiMove = game.ai_move();
         game.make_move(aiMove[0], aiMove[1]);
         const aiNow = performance.now();


### PR DESCRIPTION
## Summary
- document color choice prompt in README
- implement color selection in the console game
- shorten comment on `evaluate_for`
- remove `evaluate_for` and pass perspective into `evaluate`
- add test ensuring scores match the chosen perspective
- add test verifying win evaluation outranks four in a row

## Testing
- `cargo test --quiet`
- `rustup component add rustfmt` *(fails: unsuccessful tunnel)*

------
https://chatgpt.com/codex/tasks/task_e_686793b796fc832a86accbe7cc51a742