### PR TITLE
Disable starter radios during play

### DIFF
--- a/web/script.js
+++ b/web/script.js
@@ -30,6 +30,8 @@ function endGame(msg) {
     gameOver = true;
     startButton.disabled = false;
     startButton.textContent = 'Restart';
+    playerFirstRadio.disabled = false;
+    aiFirstRadio.disabled = false;
 }
 
 // Basic shaders for 2D rendering
@@ -217,6 +219,8 @@ function startGame() {
     messageDiv.textContent = '';
     infoDiv.textContent = '';
     startButton.disabled = true; // disable startButton when game is started.
+    playerFirstRadio.disabled = true;
+    aiFirstRadio.disabled = true;
     recentMoves = [];
     lastMove = null;
     if (animRequestId) {


### PR DESCRIPTION
## Summary
- disable AI/player starter radio buttons after the game starts
- enable them again when the game ends

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68686fe7b4e4832aa731835f7470f34a